### PR TITLE
Replace stub with bootstrapFiles for Eloquent class alias

### DIFF
--- a/bootstrap/eloquent.php
+++ b/bootstrap/eloquent.php
@@ -1,0 +1,5 @@
+<?php
+
+if (!class_exists('Eloquent')) {
+    class_alias(\Illuminate\Database\Eloquent\Model::class, 'Eloquent');
+}

--- a/extension.neon
+++ b/extension.neon
@@ -4,5 +4,5 @@ includes:
 parameters:
     level: 8
     tmpDir: .phpstan
-    stubFiles:
-        - stubs/Eloquent.stub
+    bootstrapFiles:
+        - bootstrap/eloquent.php

--- a/stubs/Eloquent.stub
+++ b/stubs/Eloquent.stub
@@ -1,3 +1,0 @@
-<?php
-
-class Eloquent extends \Illuminate\Database\Eloquent\Model {}


### PR DESCRIPTION
## Summary
- Replaces `stubFiles` with `bootstrapFiles` for the Eloquent class alias
- Stubs only override PHPDocs of existing classes, they don't make classes discoverable
- `bootstrapFiles` runs `class_alias()` which properly registers `Eloquent` so phpstan can find it
- Fixes flaky `class.notFound` for `@mixin \Eloquent` in CI

## Test plan
- [ ] Verify phpstan no longer reports `class.notFound` for `@mixin \Eloquent` in CI